### PR TITLE
Pass providers explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,36 @@ Route table creation with subnet association. Cross subscription routing from a 
 2. Calling the module;
 
 ```terraform
+provider "azurerm" {
+    version         = "~> 1.41"
+    alias           = "src"
+    subscription_id = var.SubscriptionId
+}
+
+provider "azurerm" {
+    version         = "~> 1.41"
+    alias           = "dst"
+    subscription_id = var.SubscriptionId
+}
+
 module "create" {
-    source                  = "github.com/ukho/tfmodule-azure-routetable-hub-spoke"
-    spokesubscriptionid     =  var.spokesubscriptionid
-    hubsubscriptionid       =  var.hubsubscriptionid
-    spokerg                 =  var.spokerg
-    hubrg                   =  var.hubrg
-    hubrt                   =  var.hubrt
-    id                      =  var.id
-    routetable              =  var.routetable
-    routeaddress            =  var.routeaddress
-    route                   =  var.route
-    hop                     =  var.hop
-    api                     =  var.api
-    nsb                     =  var.nsb
-    web                     =  var.web
-    hubprefix               =  var.hubprefix
-    spokeprefix             =  var.spokeprefix 
+    source        = "github.com/ukho/tfmodule-azure-routetable-hub-spoke"
+    providers     = {
+                      azurerm.hub   = "azurerm.dst" # Provider defined above (dst) is mapped to a provider (hub) in the module
+                      azurerm.spoke = "azurerm.src"
+                    }
+    spokerg       =  var.spokerg
+    hubrg         =  var.hubrg
+    hubrt         =  var.hubrt
+    id            =  var.id
+    routetable    =  var.routetable
+    routeaddress  =  var.routeaddress
+    route         =  var.route
+    hop           =  var.hop
+    api           =  var.api
+    nsb           =  var.nsb
+    web           =  var.web
+    hubprefix     =  var.hubprefix
+    spokeprefix   =  var.spokeprefix 
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,9 @@
-
-  terraform {
-  backend "azurerm" {
-    resource_group_name           = ""
-    storage_account_name          = ""
-    container_name                = ""
-    key                           = ""
-  }
-}
-
 provider "azurerm" {
-  version = "~> 1.40" #2.1
-  alias = "spoke"
-  subscription_id = var.spokesubscriptionid
-}
-
-provider "azurerm" {
-  version = "~> 1.40" #2.1
   alias = "hub"
-  subscription_id = var.hubsubscriptionid
+}
+
+provider "azurerm" {
+  alias = "spoke"
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,3 @@
-  
-variable "spokesubscriptionid" {
-  description = "name of spoke subscription"
-}
-variable "hubsubscriptionid" {
-  description = "name of hub subscription"
-}
 variable "spokerg" {
   description = "name of spoke resource group"
 }


### PR DESCRIPTION
Shaun ran into the problem where he couldn't delete this module from the terraform. This appears to be due to us defining the providers in the module itself. Instead we are supposed to define the providers in the root TF and pass the provider in explicitly. 

The summary of the problem is that as we define the providers in the module, when we remove the module from the terraform, this removes from the providers as well. Terraform then doesn't know which provider in needs to use to delete the module resources and then promptly explodes.

Relevant StackOverflow that shows the same problem and explains it - 
https://stackoverflow.com/questions/58393294/terraform-refactoring-modules-error-provider-configuration-not-present

This PR switches to passing the providers explicitly and removes the providers from the module itself.

The biggest problem with this PR is the declaration of the modules at the root level means you have to add a "Provider" to each resource at the root level which is more clumsy.

More details: 
- [Providers within modules](https://www.terraform.io/docs/configuration/modules.html#providers-within-modules)
- [Passing Providers Explicitly](https://www.terraform.io/docs/configuration/modules.html#passing-providers-explicitly)